### PR TITLE
Update in how install and update works together

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,22 +3,17 @@
 const kexec = require('kexec');
 const nodeNightly = require('./');
 const existsSync = require('fs').existsSync;
-const mv = require('fs').rename;
 
 let args = process.argv.slice(2);
 
 // Check for upgrade.
 let index = args.indexOf('--upgrade');
 if(!!~index) {
-	nodeNightly.update().then(_ => {
-		mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
-		available();
-		process.exit(0);
-	}).catch(console.log);
+	nodeNightly.update().then(process.exit(0)).catch(console.log);
 } else if(!existsSync(`${__dirname}/node-nightly`)) {
 	//First install
 	console.log('Downloading the nightly version, hang on...');
-	nodeNightly.install().then(available).catch(console.error);
+	nodeNightly.install().then(process.exit(0));
 } else {
 	nodeNightly.check().then(updatedVersion => {
 		if(updatedVersion) {
@@ -26,8 +21,4 @@ if(!!~index) {
 		}
 		kexec(`${__dirname}/node-nightly/bin/node`, args);
 	}).catch(console.error);
-}
-
-function available() {
-	console.log(`node-nightly is available on your CLI!`);
 }

--- a/cli.js
+++ b/cli.js
@@ -20,8 +20,8 @@ if(!!~index) {
   console.log('Downloading the nightly version, hang on...');
   nodeNightly.install();
 } else {
-  nodeNightly.check().then(update => {
-	  if(update) {
+  nodeNightly.check().then(updatedVersion => {
+	  if(updatedVersion) {
 	    console.log('\x1b[36m', 'New nightly available. To upgrade: `node-nightly --upgrade`' ,'\x1b[0m');
 	  }
 	  kexec(`${__dirname}/node-nightly/bin/node`, args);

--- a/cli.js
+++ b/cli.js
@@ -3,8 +3,6 @@
 const kexec = require('kexec');
 const nodeNightly = require('./');
 const existsSync = require('fs').existsSync;
-const Configstore = require('configstore');
-const pkg = require('./package.json');
 const mv = require('fs').rename;
 
 let args = process.argv.slice(2);

--- a/cli.js
+++ b/cli.js
@@ -6,10 +6,7 @@ const existsSync = require('fs').existsSync;
 const Configstore = require('configstore');
 const pkg = require('./package.json');
 const mv = require('fs').rename;
-const nodeNightlyVersion = require('node-nightly-version');
 
-const extractDate = versionString => ~~versionString.split('nightly')[1].slice(0,8);
-const compVersion = (currentVersion, latestVersion) => extractDate(currentVersion) < extractDate(latestVersion);
 let args = process.argv.slice(2);
 
 // Check for upgrade.

--- a/cli.js
+++ b/cli.js
@@ -12,15 +12,13 @@ let index = args.indexOf('--upgrade');
 if(!!~index) {
 	nodeNightly.update().then(_ => {
 		mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
-		console.log('node-nightly is available on your CLI! ');
+		available();
 		process.exit(0);
 	}).catch(console.log);
 } else if(!existsSync(`${__dirname}/node-nightly`)) {
 	//First install
 	console.log('Downloading the nightly version, hang on...');
-	nodeNightly.install().then(_ => {
-		console.log('node-nightly is available on your CLI! ');
-	}).catch(console.error);
+	nodeNightly.install().then(available).catch(console.error);
 } else {
 	nodeNightly.check().then(updatedVersion => {
 		if(updatedVersion) {
@@ -28,4 +26,8 @@ if(!!~index) {
 		}
 		kexec(`${__dirname}/node-nightly/bin/node`, args);
 	}).catch(console.error);
+}
+
+function available() {
+	console.log(`node-nightly is available on your CLI!`);
 }

--- a/cli.js
+++ b/cli.js
@@ -10,20 +10,22 @@ let args = process.argv.slice(2);
 // Check for upgrade.
 let index = args.indexOf('--upgrade');
 if(!!~index) {
-  nodeNightly.update().then(_ => {
-    mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
-    console.log('node-nightly is available on your CLI! ');
-    process.exit(0);
-  }).catch(console.log);
+	nodeNightly.update().then(_ => {
+		mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
+		console.log('node-nightly is available on your CLI! ');
+		process.exit(0);
+	}).catch(console.log);
 } else if(!existsSync(`${__dirname}/node-nightly`)) {
-  //First install
-  console.log('Downloading the nightly version, hang on...');
-  nodeNightly.install();
+	//First install
+	console.log('Downloading the nightly version, hang on...');
+	nodeNightly.install().then(_ => {
+		console.log('node-nightly is available on your CLI! ');
+	}).catch(console.error);
 } else {
-  nodeNightly.check().then(updatedVersion => {
-	  if(updatedVersion) {
-	    console.log('\x1b[36m', 'New nightly available. To upgrade: `node-nightly --upgrade`' ,'\x1b[0m');
-	  }
-	  kexec(`${__dirname}/node-nightly/bin/node`, args);
+	nodeNightly.check().then(updatedVersion => {
+		if(updatedVersion) {
+			console.log('\x1b[36m', 'New nightly available. To upgrade: `node-nightly --upgrade`' ,'\x1b[0m');
+		}
+		kexec(`${__dirname}/node-nightly/bin/node`, args);
 	}).catch(console.error);
 }

--- a/cli.js
+++ b/cli.js
@@ -5,6 +5,7 @@ const nodeNightly = require('./');
 const existsSync = require('fs').existsSync;
 const Configstore = require('configstore');
 const pkg = require('./package.json');
+const mv = require('fs').rename;
 const nodeNightlyVersion = require('node-nightly-version');
 
 const extractDate = versionString => ~~versionString.split('nightly')[1].slice(0,8);
@@ -14,22 +15,20 @@ let args = process.argv.slice(2);
 // Check for upgrade.
 let index = args.indexOf('--upgrade');
 if(!!~index) {
-  args = args.splice(index, 1);
   nodeNightly.update().then(_ => {
     mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
     console.log('node-nightly is available on your CLI! ');
     process.exit(0);
-  })
+  }).catch(console.log);
 } else if(!existsSync(`${__dirname}/node-nightly`)) {
   //First install
   console.log('Downloading the nightly version, hang on...');
   nodeNightly.install();
 } else {
-  nodeNightlyVersion().then(latestVersion => {
-      const currentVersion = new Configstore(pkg.name).get('version');
-      if(compVersion(currentVersion, latestVersion)) {
-        console.log('\x1b[36m', 'New nightly available. To upgrade: `node-nightly --upgrade`' ,'\x1b[0m');
-      }
-      kexec(`${__dirname}/node-nightly/bin/node`, args);
-    }).catch(console.error);
+  nodeNightly.check().then(update => {
+	  if(update) {
+	    console.log('\x1b[36m', 'New nightly available. To upgrade: `node-nightly --upgrade`' ,'\x1b[0m');
+	  }
+	  kexec(`${__dirname}/node-nightly/bin/node`, args);
+	}).catch(console.error);
 }

--- a/cli.js
+++ b/cli.js
@@ -9,11 +9,16 @@ let args = process.argv.slice(2);
 // Check for upgrade.
 let index = args.indexOf('--upgrade');
 if(!!~index) {
-	nodeNightly.update().then(process.exit(0)).catch(console.log);
+	nodeNightly.update().then(res => {
+		if(res !== 'Installed') {
+			console.log(res);
+		}
+		process.exit(0);
+	}).catch(console.error);
 } else if(!existsSync(`${__dirname}/node-nightly`)) {
 	//First install
 	console.log('Downloading the nightly version, hang on...');
-	nodeNightly.install().then(process.exit(0));
+	nodeNightly.install().catch(console.error);
 } else {
 	nodeNightly.check().then(updatedVersion => {
 		if(updatedVersion) {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = {
 			const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.tar.gz`;
 			return download(url, __dirname, {extract:true});
 		}).then(available)
-		.catch(console.error);
 	},
 	update: function() {
 		console.log('Checking for update...');
@@ -38,7 +37,7 @@ module.exports = {
 				return this.install(updatedVersion);
 			}
 			//reject this promise if update is not found
-			return Promise.reject('You are using latest version already.');
+			return 'You are using latest version already.';
 		});
 	},
 	check: function() {
@@ -55,5 +54,5 @@ module.exports = {
 function available() {
 	mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
 	console.log(`node-nightly is available on your CLI!`);
-	return true;
+	return 'Installed';
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const Configstore = require('configstore');
 const pkg = require('./package.json');
 const rm = require('rimraf');
 
+const extractDate = versionString => ~~versionString.split('nightly')[1].slice(0,8);
+const compVersion = (currentVersion, latestVersion) => extractDate(currentVersion) < extractDate(latestVersion);
+
 module.exports = {
   install: () => {
 		let osArchString;
@@ -35,7 +38,7 @@ module.exports = {
   	});
   },
   check: function() {
-  	return nodeNightlyVersion().then(latest => {
+  	return nodeNightlyVersion().then(latestVersion => {
   		const currentVersion = new Configstore(pkg.name).get('version');
   		if(compVersion(currentVersion, latestVersion)) {
         return true;

--- a/index.js
+++ b/index.js
@@ -9,9 +9,11 @@ const extractDate = versionString => ~~versionString.split('nightly')[1].slice(0
 const compVersion = (currentVersion, latestVersion) => extractDate(currentVersion) < extractDate(latestVersion);
 
 module.exports = {
-  install: () => {
-		let osArchString;
-    return nodeNightlyVersion().then(latest => {
+  install: (version) => {
+		let osArchString,nodeNightlyVer;
+		nodeNightlyVer = version !== undefined ? Promise.resolve(version) : nodeNightlyVersion();
+
+    return nodeNightlyVer.then(latest => {
     	const conf = new Configstore(pkg.name);
       conf.set('version', latest);
       const os = process.platform;
@@ -24,14 +26,14 @@ module.exports = {
   },
   update: function() {
   	console.log('Checking for update...');
-  	return this.check().then(update => {
+  	return this.check().then(updatedVersion => {
   		process.stdout.write('\x1B[2J\x1B[0f'); //clear previous console
-  		if(update) {
+  		if(updatedVersion) {
   			//update found
   			console.log('Deleting old version');
     		rm.sync('./node-nightly');
     		console.log(`Deleted!\nInstalling newer version..`);
-    		return this.install();
+    		return this.install(updatedVersion);
   		}
   		//reject this promise if update is not found
   		return Promise.reject('You are using latest version already.');
@@ -41,7 +43,7 @@ module.exports = {
   	return nodeNightlyVersion().then(latestVersion => {
   		const currentVersion = new Configstore(pkg.name).get('version');
   		if(compVersion(currentVersion, latestVersion)) {
-        return true;
+        return latestVersion;
       }
       return false;
   	});

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const nodeNightlyVersion = require('node-nightly-version');
 const Configstore = require('configstore');
 const pkg = require('./package.json');
 const rm = require('rimraf');
+const mv = require('fs').rename;
 
 const extractDate = versionString => ~~versionString.split('nightly')[1].slice(0,8);
 const compVersion = (currentVersion, latestVersion) => extractDate(currentVersion) < extractDate(latestVersion);
@@ -22,7 +23,8 @@ module.exports = {
 			osArchString = `${latest}-${os}-${arch}`;
 			const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.tar.gz`;
 			return download(url, __dirname, {extract:true});
-		});
+		}).then(available)
+		.catch(console.error);
 	},
 	update: function() {
 		console.log('Checking for update...');
@@ -48,4 +50,10 @@ module.exports = {
 			return false;
 		});
 	}
+};
+
+function available() {
+	mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
+	console.log(`node-nightly is available on your CLI!`);
+	return true;
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ module.exports = {
 	update: function() {
 		console.log('Checking for update...');
 		return this.check().then(updatedVersion => {
-			process.stdout.write('\x1B[2J\x1B[0f'); //clear previous console
 			if(updatedVersion) {
 				//update found
 				console.log('Deleting old version');
@@ -40,7 +39,6 @@ module.exports = {
 				console.log(`Deleted!\nInstalling newer version..`);
 				return this.install(updatedVersion);
 			}
-			//reject this promise if update is not found
 			return 'You are using latest version already.';
 		});
 	},

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const compVersion = (currentVersion, latestVersion) => extractDate(currentVersio
 
 module.exports = {
 	install: (version) => {
-		let osArchString,nodeNightlyVer;
+		let osArchString, nodeNightlyVer;
 		nodeNightlyVer = version !== undefined ? Promise.resolve(version) : nodeNightlyVersion();
 
 		return nodeNightlyVer.then(latest => {
@@ -23,7 +23,11 @@ module.exports = {
 			osArchString = `${latest}-${os}-${arch}`;
 			const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.tar.gz`;
 			return download(url, __dirname, {extract:true});
-		}).then(available)
+		}).then(_ => {
+			mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
+			console.log(`node-nightly is available on your CLI!`);
+			return 'Installed';
+		})
 	},
 	update: function() {
 		console.log('Checking for update...');
@@ -51,8 +55,3 @@ module.exports = {
 	}
 };
 
-function available() {
-	mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
-	console.log(`node-nightly is available on your CLI!`);
-	return 'Installed';
-};

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
   		return Promise.reject('You are using latest version already.');
   	});
   },
-  checkU: function() {
+  check: function() {
   	return nodeNightlyVersion().then(latest => {
   		const currentVersion = new Configstore(pkg.name).get('version');
   		if(compVersion(currentVersion, latestVersion)) {

--- a/index.js
+++ b/index.js
@@ -3,27 +3,44 @@ const download = require('download');
 const nodeNightlyVersion = require('node-nightly-version');
 const Configstore = require('configstore');
 const pkg = require('./package.json');
-const mv = require('fs').rename;
 const rm = require('rimraf');
 
 module.exports = {
   install: () => {
-  		let osArchString;
-      return nodeNightlyVersion().then(latest => {
-      	const conf = new Configstore(pkg.name);
-        conf.set('version', latest);
-        const os = process.platform;
-        const arch = process.arch;
-        const type = 'nightly';
-        osArchString = `${latest}-${os}-${arch}`;
-        const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.tar`;
-        return download(url, __dirname, {extract:true});
-      })
+		let osArchString;
+    return nodeNightlyVersion().then(latest => {
+    	const conf = new Configstore(pkg.name);
+      conf.set('version', latest);
+      const os = process.platform;
+      const arch = process.arch;
+      const type = 'nightly';
+      osArchString = `${latest}-${os}-${arch}`;
+      const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.tar.gz`;
+      return download(url, __dirname, {extract:true});
+    });
   },
   update: function() {
-    console.log('Deleting old version');
-    rm.sync('./node-nightly');
-    console.log(`Deleted!\nInstalling newer version..`);
-    return this.install();
+  	console.log('Checking for update...');
+  	return this.check().then(update => {
+  		process.stdout.write('\x1B[2J\x1B[0f'); //clear previous console
+  		if(update) {
+  			//update found
+  			console.log('Deleting old version');
+    		rm.sync('./node-nightly');
+    		console.log(`Deleted!\nInstalling newer version..`);
+    		return this.install();
+  		}
+  		//reject this promise if update is not found
+  		return Promise.reject('You are using latest version already.');
+  	});
+  },
+  checkU: function() {
+  	return nodeNightlyVersion().then(latest => {
+  		const currentVersion = new Configstore(pkg.name).get('version');
+  		if(compVersion(currentVersion, latestVersion)) {
+        return true;
+      }
+      return false;
+  	});
   }
 };

--- a/index.js
+++ b/index.js
@@ -9,43 +9,43 @@ const extractDate = versionString => ~~versionString.split('nightly')[1].slice(0
 const compVersion = (currentVersion, latestVersion) => extractDate(currentVersion) < extractDate(latestVersion);
 
 module.exports = {
-  install: (version) => {
+	install: (version) => {
 		let osArchString,nodeNightlyVer;
 		nodeNightlyVer = version !== undefined ? Promise.resolve(version) : nodeNightlyVersion();
 
-    return nodeNightlyVer.then(latest => {
-    	const conf = new Configstore(pkg.name);
-      conf.set('version', latest);
-      const os = process.platform;
-      const arch = process.arch;
-      const type = 'nightly';
-      osArchString = `${latest}-${os}-${arch}`;
-      const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.tar.gz`;
-      return download(url, __dirname, {extract:true});
-    });
-  },
-  update: function() {
-  	console.log('Checking for update...');
-  	return this.check().then(updatedVersion => {
-  		process.stdout.write('\x1B[2J\x1B[0f'); //clear previous console
-  		if(updatedVersion) {
-  			//update found
-  			console.log('Deleting old version');
-    		rm.sync('./node-nightly');
-    		console.log(`Deleted!\nInstalling newer version..`);
-    		return this.install(updatedVersion);
-  		}
-  		//reject this promise if update is not found
-  		return Promise.reject('You are using latest version already.');
-  	});
-  },
-  check: function() {
-  	return nodeNightlyVersion().then(latestVersion => {
-  		const currentVersion = new Configstore(pkg.name).get('version');
-  		if(compVersion(currentVersion, latestVersion)) {
-        return latestVersion;
-      }
-      return false;
-  	});
-  }
+		return nodeNightlyVer.then(latest => {
+			const conf = new Configstore(pkg.name);
+			conf.set('version', latest);
+			const os = process.platform;
+			const arch = process.arch;
+			const type = 'nightly';
+			osArchString = `${latest}-${os}-${arch}`;
+			const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.tar.gz`;
+			return download(url, __dirname, {extract:true});
+		});
+	},
+	update: function() {
+		console.log('Checking for update...');
+		return this.check().then(updatedVersion => {
+			process.stdout.write('\x1B[2J\x1B[0f'); //clear previous console
+			if(updatedVersion) {
+				//update found
+				console.log('Deleting old version');
+				rm.sync('./node-nightly');
+				console.log(`Deleted!\nInstalling newer version..`);
+				return this.install(updatedVersion);
+			}
+			//reject this promise if update is not found
+			return Promise.reject('You are using latest version already.');
+		});
+	},
+	check: function() {
+		return nodeNightlyVersion().then(latestVersion => {
+			const currentVersion = new Configstore(pkg.name).get('version');
+			if(compVersion(currentVersion, latestVersion)) {
+				return latestVersion;
+			}
+			return false;
+		});
+	}
 };


### PR DESCRIPTION
Ok so...

- Upgrade Workflow changes 
    * **Before**
        > when user sends an `--upgrade` flag with command, we are disposing that task to `.update()` method in our code that  was blindly installing the latest node-nightly from mirror even if user has upto date version installed in his system. 

    * **After**
        > Now when user send an `--upgrade` flag with command, we are first checking if the user already has latest version using `.check()` method in our code, if user has latest one then we are rejecting the promise with a reason that _You already have latest version_ . Now if user does not have the updated version then we are calling `.install()` method with a parameter `version`. and now instead of going to `nodeNightlyVersion()` to get latest version we are directly using this version and then proceeding with installing and all.

- Install workflow changes
   Now since we are reusing previously computed `nodeNightlyVerison()` from `.check()` in case of `.update()`, then `install()` cycle in case of `upgrade()` is improved.


PS  __Test this code thoroughly before merging__

@hemanth :ant: 