### PR TITLE
Make it work on windows with some tweaks

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
-const kexec = require('kexec');
+
+const spawn = require('cross-spawn').spawn;
 const nodeNightly = require('./');
 const existsSync = require('graceful-fs').existsSync;
 
@@ -9,21 +10,38 @@ let args = process.argv.slice(2);
 // Check for upgrade.
 let index = args.indexOf('--upgrade');
 if(!!~index) {
+
 	nodeNightly.update().then(res => {
 		if(res !== 'Installed') {
 			console.log(res);
 		}
 		process.exit(0);
-	}).catch(console.error);
+	})
+	.catch(console.error);
+
 } else if(!existsSync(`${__dirname}/node-nightly`)) {
 	//First install
 	console.log('Downloading the nightly version, hang on...');
 	nodeNightly.install().catch(console.error);
+
 } else {
-	nodeNightly.check().then(updatedVersion => {
-		if(updatedVersion) {
+
+	nodeNightly.check().then(isUpdateAvailable => {
+
+		if(isUpdateAvailable) {
 			console.log('\x1b[36m', 'New nightly available. To upgrade: `node-nightly --upgrade`' ,'\x1b[0m');
 		}
-		kexec(`${__dirname}/node-nightly/bin/node`, args);
-	}).catch(console.error);
+
+		let path;
+		if(/^win/.test(process.platform)) {
+			//if it's a windows platform
+			path = `${__dirname}/node-nightly/node.exe`;
+		} else {
+			//other than windows
+			path = `${__dirname}/node-nightly/bin/node`;
+		}
+		spawn(path, args,  {stdio: 'inherit', env: process.env});
+
+	})
+	.catch(console.error);
 }

--- a/index.js
+++ b/index.js
@@ -13,26 +13,41 @@ const extractDate = versionString => ~~versionString.split('nightly')[1].slice(0
 const compVersion = (currentVersion, latestVersion) => extractDate(currentVersion) < extractDate(latestVersion);
 
 module.exports = {
+
 	install: (version) => {
+
 		let osArchString, nodeNightlyVer;
 		nodeNightlyVer = version !== undefined ? Promise.resolve(version) : nodeNightlyVersion();
 
-		return nodeNightlyVer.then(latest => {
+		return nodeNightlyVersion().then(latest => {
+
 			const conf = new Configstore(pkg.name);
 			conf.set('version', latest);
-			const os = process.platform;
+			const platform = process.platform;
+			//Window's test start
+			const isWin = /^win/.test(platform);
+			const os = isWin? 'win': platform;
+			const extension = isWin? 'zip': 'tar.gz';
+			//window's test end
 			const arch = process.arch;
 			const type = 'nightly';
 			osArchString = `${latest}-${os}-${arch}`;
-			const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.tar.gz`;
+			const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.${extension}`;
 			return download(url, __dirname, {extract:true});
+
 		}).then(_ => {
+
+			console.log('Finalizing stuff...!');
 			mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
-			console.log(`node-nightly is available on your CLI!`);
+			console.log('node-nightly is available on your CLI! ');
 			return 'Installed';
-		})
+
+		});
+
 	},
+
 	update: function() {
+
 		console.log('Checking for update...');
 		return this.check().then(updatedVersion => {
 			if(updatedVersion) {
@@ -44,8 +59,11 @@ module.exports = {
 			}
 			return 'You are using latest version already.';
 		});
+
 	},
+
 	check: function() {
+
 		return nodeNightlyVersion().then(latestVersion => {
 			const currentVersion = new Configstore(pkg.name).get('version');
 			if(compVersion(currentVersion, latestVersion)) {
@@ -53,6 +71,7 @@ module.exports = {
 			}
 			return false;
 		});
-	}
-};
 
+	}
+
+};

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   ],
   "dependencies": {
     "configstore": "^2.0.0",
+    "cross-spawn": "^4.0.0",
     "download": "^5.0.2",
     "graceful-fs": "^4.1.4",
-    "kexec": "^2.0.2",
     "node-nightly-version": "^1.0.0",
     "rimraf": "^2.5.2"
   }


### PR DESCRIPTION
Updates :-
   1. Some node specific tweaks for windows like
       1.1 Using .zip instead of .tar.gz if it's windows
       1.2 Using os as 'win' instead of 'win32' which is returned by process.platform
       1.3 Executing node-nightly binary from /node-nightly/node instead of /node-nightly/bin/node


   2. Use cross-spawn