### PR TITLE
Add --version option and make more robust

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,9 +9,14 @@ const os = process.platform  === 'win32' ? 'win' : process.platform;
 let args = process.argv.slice(2);
 
 // Check for upgrade.
-let index = args.indexOf('--upgrade');
-if(!!~index) {
+let upgradeIndex = args.indexOf('--upgrade'),
+    versionIndex = args.indexOf('--version'),
+    version = versionIndex < 0 ? null : args[versionIndex + 1];
 
+if (version) {
+	nodeNightly.install(version).catch(console.error);
+}
+else if(!!~upgradeIndex) {
 	reportIfOffline();
 	nodeNightly.update().then(res => {
 		if(res !== 'Installed') {

--- a/index.js
+++ b/index.js
@@ -7,51 +7,65 @@ const rm = require('rimraf');
 const realFs = require('fs');
 const gracefulFs = require('graceful-fs');
 gracefulFs.gracefulify(realFs);
-const mv = gracefulFs.rename;
+const mv = gracefulFs.renameSync;
 
 const extractDate = versionString => ~~versionString.split('nightly')[1].slice(0, 8);
 const compVersion = (currentVersion, latestVersion) => extractDate(currentVersion) < extractDate(latestVersion);
 
 module.exports = {
+
 	install: (version) => {
 		let osArchString, nodeNightlyVer;
 		nodeNightlyVer = version !== undefined ? Promise.resolve(version) : nodeNightlyVersion();
 
 		return nodeNightlyVer.then(latest => {
-			const conf = new Configstore(pkg.name);
-			conf.set('version', latest);
-			const os = process.platform === 'win32' ? 'win' : process.platform;
-			const extention = os === 'win' ? 'zip' : 'tar.gz';
-			const arch = process.arch;
-			const type = 'nightly';
-			osArchString = `${latest}-${os}-${arch}`;
-			const url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.${extention}`;
-			return download(url, __dirname, {
-				extract: true
-			});
-		}).then(_ => {
-			mv(`${__dirname}/node-${osArchString}`, `${__dirname}/node-nightly`);
-			console.log(`node-nightly is available on your CLI!`);
-			return 'Installed';
-		})
-	},
-	update: function() {
+      const os = process.platform === 'win32' ? 'win' : process.platform,
+            extention = os === 'win' ? 'zip' : 'tar.gz',
+            arch = process.arch,
+            type = 'nightly',
+            osArchString = `${version}-${os}-${arch}`,
+            url = `https://nodejs.org/download/${type}/${version}/node-${osArchString}.${extention}`,
+            nightlyDir = `${__dirname}/node-nightly`;
+
+      const extractedTo = `${__dirname}/node-${osArchString}`;
+
+      if (gracefulFs.existsSync(extractedTo)) {
+        rm.sync(extractedTo);
+      }
+
+      return download(url, __dirname, {
+        extract: true
+      }).then(_ => {
+        if (gracefulFs.existsSync(nightlyDir)) {
+          console.log('Deleting old version');
+          rm.sync('./node-nightly');
+          console.log(`Deleted!\nInstalling newer version..`);
+        }
+
+        mv(extractedTo, nightlyDir);
+        console.log(`node-nightly is available on your CLI!`);
+
+        new Configstore(pkg.name).set('version', version);
+
+        return 'Installed';
+      });
+    });
+  },
+
+  update: function() {
 		console.log('Checking for update...');
 		return this.check().then(updatedVersion => {
 			if (updatedVersion) {
-				//update found
-				console.log('Deleting old version');
-				rm.sync('./node-nightly');
-				console.log(`Deleted!\nInstalling newer version..`);
 				return this.install(updatedVersion);
 			}
 			return 'You are using latest version already.';
 		});
 	},
+
 	check: function() {
 		return nodeNightlyVersion().then(latestVersion => {
 			const currentVersion = new Configstore(pkg.name).get('version');
-			if (compVersion(currentVersion, latestVersion)) {
+			if (!currentVersion || compVersion(currentVersion, latestVersion)) {
 				return latestVersion;
 			}
 			return false;

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,11 @@ Debugger attached.
 Waiting for the debugger to disconnect...
 ```
 
+## Additional commands
+
+ 1. `node-nightly --version {version}` Install a specific nightly. This is useful if the nightly is broken.
+ 2. `node-nightly --upgrade` Install the latest nightly
+
 __GIF FTW!__
 
 ![node-nightly](./node-nightly.gif)


### PR DESCRIPTION
I happened to grab this lib on a day when the nightly was busted and didn't have an OSX file (see [here](https://nodejs.org/download/nightly/v8.0.0-nightly201702077ba847df1c/)), so I jumped in and added a few things:

 1. A `--version` option that lets you specify a specific version
 2. Don't delete the old one or set the current version setting until we've successfully gotten the new one. That way if you `--upgrade` to a busted version you're not left with nothing.
 3. If for some reason, we were able to download the new version and extract it but not move it, delete that temp dir the next time
 4. Use synchronous move to quiet the deprecation warning about async calls with no callbacks

I'm, uh, not a real Node developer at all so I could have done any number of things wrong here.