### PR TITLE
process.arch returns ia32 instead of x86 on windows 10, node version …

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
 		return nodeNightlyVer.then(latest => {
       const os = process.platform === 'win32' ? 'win' : process.platform,
             extention = os === 'win' ? 'zip' : 'tar.gz',
-            arch = process.arch,
+            arch = process.arch === 'ia32' ? 'x86' : process.arch,
             type = 'nightly',
             osArchString = `${latest}-${os}-${arch}`,
             url = `https://nodejs.org/download/${type}/${latest}/node-${osArchString}.${extention}`,


### PR DESCRIPTION
proccess.arch returns a string ia32 instead of x86 on windows 10, Node version 7.9.0 32 bit. Due to this, node-version module fails due to the fact that it can't find platform called win32-ia32. 

I did a quick fix by adding ternary expression that will make process.arg use x86 instead of ia32.